### PR TITLE
composer.json: Depend on specific symfony components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,9 @@
         }
     },
     "require": {
-        "symfony/symfony": "~2.3"
+        "symfony/config": "~2.3",
+        "symfony/dependency-injection": "~2.3",
+        "symfony/http-kernel": "~2.3"
     },
     "require-dev": {
         "phpspec/phpspec": "2.0.0"


### PR DESCRIPTION
There is no need to depend on full symfony stack.
